### PR TITLE
Adding a new port as existing ones fails

### DIFF
--- a/samples-protocol-switching/sample_proxy_1.wsdl
+++ b/samples-protocol-switching/sample_proxy_1.wsdl
@@ -352,6 +352,9 @@
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:service name="SimpleStockQuoteService">
+        <wsdl:port name="SimpleStockQuoteServiceHttpSoapDefaultEndpoint" binding="ns:SimpleStockQuoteServiceSoapDefaultBinding">
+            <soap:address location="http://localhost:9000/services/SimpleStockQuoteService"/>
+        </wsdl:port>
         <wsdl:port name="SimpleStockQuoteServiceHttpSoap11Endpoint" binding="ns:SimpleStockQuoteServiceSoap11Binding">
             <soap:address location="http://localhost:9000/services/SimpleStockQuoteService.SimpleStockQuoteServiceHttpSoap11Endpoint"/>
         </wsdl:port>


### PR DESCRIPTION
Adding a new port because it says resources pointed by other ports cannot be found when trying to run the example https://ei.docs.wso2.com/en/next/micro-integrator/use-cases/examples/endpoint_examples/using-wsdl-endpoints/